### PR TITLE
feat: try to autodetect  `localkeys` variant from current OS

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
+
 import { platform } from 'os';
 
 import { join } from 'path';
@@ -41,7 +42,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
         await cfg.update(
           'vscode-kanata.mainConfigFile',
           fileName,
-          ConfigurationTarget.Workspace
+          ConfigurationTarget.Workspace,
         );
         // await window.showInformationMessage(
         //   `Set vscode-kanata.mainConfigFile to ${fileName}`
@@ -49,7 +50,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
       } else {
         await window.showErrorMessage('No active editor');
       }
-    }
+    },
   );
   ctx.subscriptions.push(cmd1);
 
@@ -74,7 +75,7 @@ class Extension implements Disposable {
     this.ctx = ctx;
 
     this.ctx.subscriptions.push(
-      workspace.onDidChangeConfiguration(this.restart())
+      workspace.onDidChangeConfiguration(this.restart()),
     );
   }
 
@@ -84,14 +85,14 @@ class Extension implements Disposable {
     if (openedWorkspaces) {
       if (openedWorkspaces.length >= 2) {
         await window.showInformationMessage(
-          'Multiple workspaces are currently not supported, only the first workspaces folder will be regarded.'
+          'Multiple workspaces are currently not supported, only the first workspaces folder will be regarded.',
         );
       }
       root = openedWorkspaces.at(0);
     }
 
     outputChannel.appendLine(
-      `starting with ${openedWorkspaces?.length || 0} opened workspaces`
+      `starting with ${openedWorkspaces?.length || 0} opened workspaces`,
     );
 
     await this.startClient(root);
@@ -115,13 +116,13 @@ class Extension implements Disposable {
         kanataFilesInFolderPattern(root.uri),
         true, // ignoreCreateEvents
         true, // ignoreChangeEvents
-        false // ignoreDeleteEvents
+        false, // ignoreDeleteEvents
       );
       changeWatcher = workspace.createFileSystemWatcher(
         kanataFilesInFolderPattern(root.uri),
         false, // ignoreCreateEvents
         false, // ignoreChangeEvents
-        true // ignoreDeleteEvents
+        true, // ignoreDeleteEvents
       );
 
       // Clean up watchers when extension is deactivated.
@@ -183,14 +184,14 @@ class Extension implements Disposable {
         await this.start();
       } else {
         outputChannel.appendLine(
-          "Settings changed but vscode-kanata configuration hasn't changed"
+          "Settings changed but vscode-kanata configuration hasn't changed",
         );
       }
     };
   }
 
   dispose() {
-    this.toDisposeOnRestart.forEach(disposable => {
+    this.toDisposeOnRestart.forEach((disposable) => {
       disposable.dispose();
     });
   }

--- a/kls/src/lib.rs
+++ b/kls/src/lib.rs
@@ -46,7 +46,6 @@ impl Kanata {
             }
             DefLocalKeysVariant::Linux => kanata_parser::keys::Platform::Linux,
             DefLocalKeysVariant::MacOS => kanata_parser::keys::Platform::Macos,
-            DefLocalKeysVariant::NotSet => unreachable!(),
         };
         Self {
             def_local_keys_variant_to_apply: def_local_keys_variant_to_apply.to_string(),
@@ -163,8 +162,6 @@ enum IncludesAndWorkspaces {
 
 #[derive(Debug, Deserialize, Clone, Copy)]
 enum DefLocalKeysVariant {
-    #[serde(rename = "not-set")]
-    NotSet,
     #[serde(rename = "deflocalkeys-win")]
     Win,
     #[serde(rename = "deflocalkeys-wintercept")]
@@ -178,7 +175,6 @@ enum DefLocalKeysVariant {
 impl Display for DefLocalKeysVariant {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DefLocalKeysVariant::NotSet => f.write_str("not-set"),
             DefLocalKeysVariant::Win => f.write_str("deflocalkeys-win"),
             DefLocalKeysVariant::Wintercept => f.write_str("deflocalkeys-wintercept"),
             DefLocalKeysVariant::Linux => f.write_str("deflocalkeys-linux"),
@@ -250,11 +246,7 @@ impl KanataLanguageServer {
 
         Self {
             documents: BTreeMap::new(),
-            kanata: Kanata::new(match config.def_local_keys_variant {
-                // use windows localkeys as fallback
-                DefLocalKeysVariant::NotSet => DefLocalKeysVariant::Win,
-                x => x,
-            }),
+            kanata: Kanata::new(config.def_local_keys_variant),
             workspace_options: config.into(),
             root: root_uri,
             send_diagnostics_callback: send_diagnostics_callback.clone(),

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
             "deflocalkeys-linux",
             "deflocalkeys-macos"
           ],
-          "default": "not-set",
+          "default": "auto",
           "markdownDescription": "Select which localkeys variant to use."
         }
       }

--- a/test/src/runTest.ts
+++ b/test/src/runTest.ts
@@ -16,7 +16,7 @@ void (async function () {
     const extensionTestsPath = resolve(__dirname, './suite');
     const workspace = resolve(
       __dirname,
-      '../../../test-fixtures/workspace/test.code-workspace'
+      '../../../test-fixtures/workspace/test.code-workspace',
     );
 
     await runTests({


### PR DESCRIPTION
Closes #11 

- Rename `localKeysVariant` option enum from "not-set" to "auto"
- Add `localKeysVariant` autodetection when set to "auto"

Since this is only detection based on current OS, Windows users, by the fact that there are 2 possible variants, can't rely on "auto" and still have to correct it manually.