### PR TITLE
fix: CRLF newlines in defsrc causing formatter to crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-* no changes yet
+* Fixed CRLF newlines in defsrc causing formatter to crash
 
 ### 0.8.4
 

--- a/kls/src/formatter/defsrc_layout/mod.rs
+++ b/kls/src/formatter/defsrc_layout/mod.rs
@@ -10,6 +10,7 @@ impl ExtParseTree {
     // TODO: maybe don't format if an atom in defsrc/deflayer is too large.
     // TODO: respect `tab_size`.
     // TODO: respect `insert_spaces` formatter setting.
+    // TODO: respect CRLF line endings.
     pub fn use_defsrc_layout_on_deflayers<'a>(
         &'a mut self,
         defsrc_layout: &[Vec<usize>],
@@ -143,6 +144,7 @@ impl ExtParseTree {
             let mut line_num: usize = 0;
             for ch in defsrc_item_as_str.chars() {
                 match ch {
+                    '\r' => {}
                     '\n' => {
                         layout[i].push(0);
                         line_num += 1;
@@ -166,6 +168,7 @@ impl ExtParseTree {
                     Metadata::Whitespace(whitespace) => {
                         for ch in whitespace.chars() {
                             match ch {
+                                '\r' => {}
                                 '\n' => {
                                     layout[i].push(0);
                                     line_num += 1;
@@ -461,6 +464,17 @@ mod tests {
         formats_correctly(
             "(defsrc caps w a s d) (deflayer base 1 2   3 4   5)",
             "(defsrc caps w a s d) (deflayer base 1 2 3 4 5)",
+        );
+    }
+
+    #[test]
+    fn cr_lf_line_endings() {
+        // Tests 2 things:
+        // 1. No panic (see https://github.com/rszyma/vscode-kanata/issues/20)
+        // 2. CRLF line endings applying correctly.
+        formats_correctly(
+            "(defsrc 1 \r\n 2)  (deflayer base 3 \r\n 4)",
+            "(defsrc 1 \r\n 2)  (deflayer base 3 \r\n 4)",
         );
     }
 }

--- a/kls/src/formatter/mod.rs
+++ b/kls/src/formatter/mod.rs
@@ -1,6 +1,8 @@
 pub mod ext_tree;
 use ext_tree::*;
 
+use self::defsrc_layout::LineEndingSequence;
+
 pub mod defsrc_layout;
 mod remove_excessive_newlines;
 
@@ -22,6 +24,7 @@ impl Formatter {
         tree: &mut ExtParseTree,
         options: &lsp_types::FormattingOptions, // todo: we should probably handle these options
         defsrc_layout: Option<&[Vec<usize>]>,
+        line_endings: LineEndingSequence,
     ) {
         if !self.options.enable {
             return;
@@ -37,7 +40,7 @@ impl Formatter {
                     layout,
                     options.tab_size,
                     options.insert_spaces,
-                    // is_main_config_file,
+                    line_endings,
                 )
             }
         }

--- a/kls/src/lib.rs
+++ b/kls/src/lib.rs
@@ -1,4 +1,7 @@
-use crate::helpers::{lsp_range_from_span, HashSet};
+use crate::{
+    formatter::defsrc_layout::LineEndingSequence,
+    helpers::{lsp_range_from_span, HashSet},
+};
 use anyhow::{anyhow, bail};
 use formatter::Formatter;
 use kanata_parser::cfg::{FileContentProvider, ParseError};
@@ -445,8 +448,17 @@ impl KanataLanguageServer {
         })
         .unwrap_or(None);
 
-        self.formatter
-            .format(&mut tree, &params.options, defsrc_layout.as_deref());
+        // FIXME: Generally, this shouldn't be hard-coded to LF, but I couldn't find
+        // how to get line ending sequence for the current file and vscode adjusts
+        // line endings automatically, so setting it to LF hopefully won't cause any issues.
+        let line_endings = LineEndingSequence::LF;
+
+        self.formatter.format(
+            &mut tree,
+            &params.options,
+            defsrc_layout.as_deref(),
+            line_endings,
+        );
 
         Some(vec![TextEdit {
             range,


### PR DESCRIPTION
## Describe the changes and why are you making them

Fixes https://github.com/rszyma/vscode-kanata/issues/20

## Checklist

- [x] Update CHANGELOG.md
