### PR TITLE
fix: include dash in word pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-* no changes yet
+* Fixed: include dash "-" in word pattern in language-configuration.json
 
 ### 0.13.22
 

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,4 +1,5 @@
 {
+  "wordPattern": "[^\\s)(]+",
   "comments": {
     // symbol used for single line comment.
     "lineComment": ";;",


### PR DESCRIPTION
## Describe the changes and why are you making them

<!-- Closes: #number -->

idk what the default word pattern is exactly, but it doesn't include dash "-", so i'm updating it to inlude it, while allowing including utf-8 characters too

## Checklist

- [ ] Update CHANGELOG.md
