### PR TITLE
fix(formatter): insert a space after oversized deflayer item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 * Updated kanata to [bc55298](https://github.com/jtroo/kanata/tree/bc55298)
+* Fixed: deflayer formatter wrong formatting on oversized items ([#51](https://github.com/rszyma/vscode-kanata/issues/51))
 
 ### 0.14.6
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732758367,
-        "narHash": "sha256-RzaI1RO0UXqLjydtz3GAXSTzHkpb/lLD1JD8a0W4Wpo=",
+        "lastModified": 1738824222,
+        "narHash": "sha256-U3SNq+waitGIotmgg/Et3J7o4NvUtP2gb2VhME5QXiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa42b5a5f401aab8a32bd33c9a4de0738180dc59",
+        "rev": "550e11f27ba790351d390d9eca3b80ad0f0254e7",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732802692,
-        "narHash": "sha256-kFrxb45qj52TT/OFUFyTdmvXkn/KXDUL0/DOtjHEQvs=",
+        "lastModified": 1738263856,
+        "narHash": "sha256-u9nE8Gwc+B3AIy12ZrXXxlFdBouNcB8T6Kf6jX1n2m0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "34971069ec33755b2adf2481851f66d8ec9a6bfa",
+        "rev": "9efb8a111c32f767d158bba7fa130ae0fb5cc4ba",
         "type": "github"
       },
       "original": {

--- a/kls/src/formatter/defsrc_layout/mod.rs
+++ b/kls/src/formatter/defsrc_layout/mod.rs
@@ -658,4 +658,10 @@ mod tests {
             "parsed tree did not equal to expected_result"
         );
     }
+
+    /// Regression test for https://github.com/rszyma/vscode-kanata/issues/51
+    #[test]
+    fn test_deflayer_slot_expand() {
+        should_not_format("(defsrc 1 2 3 4) (deflayer base 1 @a grv 4)");
+    }
 }

--- a/kls/src/formatter/defsrc_layout/mod.rs
+++ b/kls/src/formatter/defsrc_layout/mod.rs
@@ -320,7 +320,7 @@ fn formatted_deflayer_node_metadata_without_comments(
         if is_at_the_end_of_line || (!is_at_the_end_of_line && is_the_last_expr_in_deflayer) {
             // space-before-newline / space-before-end-paren trimming
             vec![]
-        } else if expr_graphemes_count <= formatting_to_apply[0] {
+        } else if expr_graphemes_count < formatting_to_apply[0] {
             // Expr fits inside slot.
             let n = formatting_to_apply[0] - expr_graphemes_count;
             if n > 0 {

--- a/kls/src/lib.rs
+++ b/kls/src/lib.rs
@@ -891,7 +891,7 @@ impl KanataLanguageServer {
                 // Compare paths (`Split<char>`) by zipping them together and comparing pairwise.
                 let compare_paths = |(l, r): (Split<_>, Split<_>)| l.zip(r).all(|(l, r)| l == r);
                 // If all path segments match b/w dir & uri, uri is in dir and should be removed.
-                maybe_segments.map_or(false, compare_paths)
+                maybe_segments.is_some_and(compare_paths)
             });
         in_removed_dir
             .iter()

--- a/kls/src/navigation/mod.rs
+++ b/kls/src/navigation/mod.rs
@@ -86,10 +86,7 @@ pub fn references_for_definition_at_pos(
     let source_doc_definition_locations = definition_locations_by_doc.get(source_doc)?;
 
     let location_info =
-        match source_doc_definition_locations.search_references_for_token_at_position(source_pos) {
-            Some(x) => x,
-            None => return None,
-        };
+        source_doc_definition_locations.search_references_for_token_at_position(source_pos)?;
     log!("{:?}", &location_info);
 
     let mut reference_links: Vec<GotoDefinitionLink> = Vec::new();


### PR DESCRIPTION
## Describe the changes and why are you making them

Issue: when the deflayer item is 1 more length that size of the slot, a space after the item is not inserted.

Closes: #51

## Checklist

- [ ] Update CHANGELOG.md
