### PR TITLE
set default vscode-kanata.localKeysVariant to deflocalkeys-winiov2

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -280,8 +280,8 @@ function getLocalKeysVariant(): LocalKeysVariant {
           .catch((e) => {
             outputChannel.appendLine(`error: ${e}`);
           });
-        // Use 'deflocalkeys-win' as a fallback, since that's the most common variant, I guess.
-        return "deflocalkeys-win";
+        // Use 'deflocalkeys-winiov2' as a fallback, since that's the most common variant, I guess.
+        return "deflocalkeys-winiov2";
     }
   }
 

--- a/kanata-ls/src/lib.rs
+++ b/kanata-ls/src/lib.rs
@@ -208,7 +208,7 @@ impl Default for Config {
             def_local_keys_variant: match std::env::consts::OS {
                 "linux" => DefLocalKeysVariant::Linux,
                 "macos" => DefLocalKeysVariant::MacOS,
-                _ => DefLocalKeysVariant::Win,
+                _ => DefLocalKeysVariant::WinIOv2,
             },
             format: ExtensionFormatterOptions {
                 enable: false,


### PR DESCRIPTION

## Checklist

- [ ] Update CHANGELOG.md
- [ ] Update README.md, if adding a new feature.
